### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ json.deserializeValidation[Foo[List[Foo[List[Foo[Int]]]]]]
 // Success(Foo(root,List(Foo(left,null), Foo(right,List(Foo(leaf,1))))))
 ```
 
-The above defaults to using [Jackson](http://jackson.codehaus.org/) for serde operations, but could be switched to anything that defines a implicit function that returns `Serialize[A, B]` (same for deserialze).
+The above defaults to using [Jackson](https://jackson.codehaus.org/) for serde operations, but could be switched to anything that defines a implicit function that returns `Serialize[A, B]` (same for deserialze).
 
 ### validate
 
@@ -136,4 +136,4 @@ import javax.validation.ConstraintViolation
   // Failure(NonEmptyList((Orchestration,version,may not be empty), (Orchestration,module,may not be empty), (Orchestration,roles,may not be empty), (Action,name,may not be empty), (Action,commands,may not be empty), (Action,name,may not be empty), (ServiceCommand,name,may not be empty), (ServiceCommand,args,may not be empty), (ResourceCommand,name,may not be empty), (ResourceCommand,args,may not be empty)))
 ```
 
-This example looks overly complex, but its showing the harder case for validate.  The default implementation uses [Hibernate Validator](http://hibernate.org/validator/) which doesn't support nested validation checks for scala.  If your object needs nested validation, you can follow the code above.  [Scalaz](https://github.com/scalaz/scalaz)'s `Validation` type will make sure all errors join together for the response
+This example looks overly complex, but its showing the harder case for validate.  The default implementation uses [Hibernate Validator](https://hibernate.org/validator/) which doesn't support nested validation checks for scala.  If your object needs nested validation, you can follow the code above.  [Scalaz](https://github.com/scalaz/scalaz)'s `Validation` type will make sure all errors join together for the response

--- a/sutils-jackson/src/main/scala/com/gopivotal/sutils/Format.scala
+++ b/sutils-jackson/src/main/scala/com/gopivotal/sutils/Format.scala
@@ -41,6 +41,6 @@ trait FormatFunctions {
 
 /**
  * Data formats commonly used with serialization.  These work with tag-types, for details on these, go
- * to http://dcapwell.github.io/scala-tour/Tag%20Types.html
+ * to https://dcapwell.github.io/scala-tour/Tag%20Types.html
  */
 object Format extends FormatFunctions


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://eed3si9n.com/scala-the-flying-sandwich-parts (200) with 1 occurrences could not be migrated:  
   ([https](https://eed3si9n.com/scala-the-flying-sandwich-parts) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jackson.codehaus.org/ (UnknownHostException) with 1 occurrences migrated to:  
  https://jackson.codehaus.org/ ([https](https://jackson.codehaus.org/) result UnknownHostException).
* http://dcapwell.github.io/scala-tour/Tag%20Types.html (404) with 1 occurrences migrated to:  
  https://dcapwell.github.io/scala-tour/Tag%20Types.html ([https](https://dcapwell.github.io/scala-tour/Tag%20Types.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://hibernate.org/validator/ with 1 occurrences migrated to:  
  https://hibernate.org/validator/ ([https](https://hibernate.org/validator/) result 200).