### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/project/build.properties
+++ b/project/build.properties
@@ -5,7 +5,7 @@
 # Version 2.0 (the "License?); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/main/scala/com/gopivotal/sutils/Deserialize.scala
+++ b/sutils-core/src/main/scala/com/gopivotal/sutils/Deserialize.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/main/scala/com/gopivotal/sutils/Serialize.scala
+++ b/sutils-core/src/main/scala/com/gopivotal/sutils/Serialize.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/main/scala/com/gopivotal/sutils/Validate.scala
+++ b/sutils-core/src/main/scala/com/gopivotal/sutils/Validate.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/main/scala/com/gopivotal/sutils/package.scala
+++ b/sutils-core/src/main/scala/com/gopivotal/sutils/package.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/test/resources/logback.xml
+++ b/sutils-core/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
   Version 2.0 (the "License”); you may not use this file except in compliance
   with the License. You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-core/src/test/scala/com/gopivotal/sutils/BaseTest.scala
+++ b/sutils-core/src/test/scala/com/gopivotal/sutils/BaseTest.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-examples/src/main/scala/SerdeExamples.scala
+++ b/sutils-examples/src/main/scala/SerdeExamples.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-examples/src/main/scala/ValidateExamples.scala
+++ b/sutils-examples/src/main/scala/ValidateExamples.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/HibernateValidate.scala
+++ b/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/HibernateValidate.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/package.scala
+++ b/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/package.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/validators/SizeValidatorForScalaCollection.scala
+++ b/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/validators/SizeValidatorForScalaCollection.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/validators/SizeValidatorForScalaOption.scala
+++ b/sutils-hibernate/src/main/scala/com/gopivotal/sutils/hibernate/validators/SizeValidatorForScalaOption.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-hibernate/src/test/scala/com/gopivotal/sutils/hibernate/HibernateValidateTest.scala
+++ b/sutils-hibernate/src/test/scala/com/gopivotal/sutils/hibernate/HibernateValidateTest.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/main/scala/com/gopivotal/sutils/Format.scala
+++ b/sutils-jackson/src/main/scala/com/gopivotal/sutils/Format.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/main/scala/com/gopivotal/sutils/Jackson.scala
+++ b/sutils-jackson/src/main/scala/com/gopivotal/sutils/Jackson.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/main/scala/com/gopivotal/sutils/JacksonDeserialize.scala
+++ b/sutils-jackson/src/main/scala/com/gopivotal/sutils/JacksonDeserialize.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/main/scala/com/gopivotal/sutils/JacksonSerialize.scala
+++ b/sutils-jackson/src/main/scala/com/gopivotal/sutils/JacksonSerialize.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/test/scala/com/gopivotal/sutils/DeserializeTest.scala
+++ b/sutils-jackson/src/test/scala/com/gopivotal/sutils/DeserializeTest.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sutils-jackson/src/test/scala/com/gopivotal/sutils/SerializeTest.scala
+++ b/sutils-jackson/src/test/scala/com/gopivotal/sutils/SerializeTest.scala
@@ -7,7 +7,7 @@
  * Version 2.0 (the "License”); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 22 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).